### PR TITLE
Removed microseconds from timestamps

### DIFF
--- a/src/Token/Builder.php
+++ b/src/Token/Builder.php
@@ -182,13 +182,6 @@ final class Builder implements BuilderInterface
      */
     private function convertDate(DateTimeImmutable $date)
     {
-        $seconds      = $date->format('U');
-        $microseconds = $date->format('u');
-
-        if ((int) $microseconds === 0) {
-            return (int) $seconds;
-        }
-
-        return $seconds . '.' . $microseconds;
+        return $date->format('U');
     }
 }

--- a/test/unit/Token/BuilderTest.php
+++ b/test/unit/Token/BuilderTest.php
@@ -405,7 +405,7 @@ final class BuilderTest extends TestCase
         $issuedAt   = new DateTimeImmutable('@1487285080');
         $expiration = DateTimeImmutable::createFromFormat('U', '1487285080');
         $headers    = ['typ' => 'JWT', 'alg' => 'RS256'];
-        $claims     = ['iat' => 1487285080, 'exp' => '1487285080', 'aud' => 'test', 'test' => 123];
+        $claims     = ['iat' => '1487285080', 'exp' => '1487285080', 'aud' => 'test', 'test' => 123];
 
         $this->encoder->expects($this->exactly(2))
                       ->method('jsonEncode')

--- a/test/unit/Token/BuilderTest.php
+++ b/test/unit/Token/BuilderTest.php
@@ -403,9 +403,9 @@ final class BuilderTest extends TestCase
         $this->signer->method('sign')->willReturn('testing');
 
         $issuedAt   = new DateTimeImmutable('@1487285080');
-        $expiration = DateTimeImmutable::createFromFormat('U.u', '1487285080.123456');
+        $expiration = DateTimeImmutable::createFromFormat('U', '1487285080');
         $headers    = ['typ' => 'JWT', 'alg' => 'RS256'];
-        $claims     = ['iat' => 1487285080, 'exp' => '1487285080.123456', 'aud' => 'test', 'test' => 123];
+        $claims     = ['iat' => 1487285080, 'exp' => '1487285080', 'aud' => 'test', 'test' => 123];
 
         $this->encoder->expects($this->exactly(2))
                       ->method('jsonEncode')


### PR DESCRIPTION
In order to be valid with https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32#page-6